### PR TITLE
Prepare repo for reboot-dev-bot's eventuals auto-updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "dev-tools"]
+	path = dev-tools
+	url = https://github.com/3rdparty/dev-tools.git
+	branch = artur.PR-bot-for-updating-eventuals


### PR DESCRIPTION
This PR adds updated dev-tools submodule which is based on `artur.PR-bot-for-updating-eventuals` branch. In this branch there all scripts needed for reboot-dev-bot.
NOTE: before merging this PR `make sure` that [PR](https://github.com/3rdparty/dev-tools/pull/47) in `3rdparty/dev-tools` was merged!!! And then change branch to main in this PR!!!