### PR TITLE
Update examples to the latest 'expected' version

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -8,10 +8,10 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "com_github_3rdparty_eventuals",
-    commit = "ae27596eab8e07beea6950b17dc959a4b907d0f6",
+    commit = "668ab09aa066b9d6d8412f46c136aa255756930a",
     recursive_init_submodules = True,
     remote = "https://github.com/3rdparty/eventuals",
-    shallow_since = "1654451413 +0000",
+    shallow_since = "1655328520 +0000",
 )
 
 load("@com_github_3rdparty_eventuals//bazel:submodules.bzl", eventuals_submodules = "submodules")

--- a/errors-4.cc
+++ b/errors-4.cc
@@ -9,7 +9,7 @@ int main(int argc, char** argv) {
   auto e = []() {
     return Just("hello")
         | Raise(std::runtime_error("Oh no!"))
-        | Finally([](Expected::Of<const char*> expected) {
+        | Finally([](expected<const char*, std::exception_ptr> expected) {
              CHECK(!expected.has_value());
              return "world";
            });

--- a/expected-1.cc
+++ b/expected-1.cc
@@ -3,11 +3,11 @@
 
 using namespace eventuals;
 
-Expected::Of<int> SomeFunction(int i) {
+expected<int> SomeFunction(int i) {
   if (i > 100) {
-    return Unexpected(std::overflow_error("> 100"));
+    return make_unexpected("> 100");
   } else {
-    return i; // return Expected(i);
+    return i; // return expected(i);
   }
 }
 


### PR DESCRIPTION
Since Ben has integrated 'tl::expected' there is a need to
update examples which use 'expected' stuff.
Check [`this`](https://github.com/3rdparty/eventuals/commit/86c2670f5a1cd3be03c9403acef88b467dbb2e51).