### PR TITLE
Update eventuals and fix build issues

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,7 +8,7 @@ build:windows --cxxopt="/std:c++17"
 
 build:windows --compiler="clang-cl"
 
-build:clang --action_env=CC=clang
+build --action_env=CC=clang
 
 # Allow users to add local preferences.
 try-import %workspace%/user.bazelrc

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -8,10 +8,10 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "com_github_3rdparty_eventuals",
-    commit = "abfec9389de4c3007aa272f7745e3c1d1286db99",
+    commit = "2a513beb5231b4c538ffa8f79f7f263300be1fb7",
     recursive_init_submodules = True,
     remote = "https://github.com/3rdparty/eventuals",
-    shallow_since = "1658405511 +0000",
+    shallow_since = "1659539652 +0000",
 )
 
 load("@com_github_3rdparty_eventuals//bazel:submodules.bzl", eventuals_submodules = "submodules")

--- a/errors-1.cc
+++ b/errors-1.cc
@@ -1,4 +1,6 @@
+#include "eventuals/compose.h"
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/raise.h"
 
 using namespace eventuals;
@@ -6,8 +8,8 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Just("hello")
-        | Raise(std::runtime_error("Oh no!"))
-        | Just("world");
+        >> Raise(std::runtime_error("Oh no!"))
+        >> Just("world");
   };
 
   try {

--- a/errors-2.cc
+++ b/errors-2.cc
@@ -1,5 +1,6 @@
 #include "eventuals/catch.h"
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/raise.h"
 
 using namespace eventuals;
@@ -7,12 +8,12 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Just("hello")
-        | Raise(std::runtime_error("Oh no!"))
-        | Catch()
-              .raised<std::runtime_error>([](std::runtime_error&& e) {
-                CHECK_STREQ("Oh no!", e.what());
-                return Just("world");
-              });
+        >> Raise(std::runtime_error("Oh no!"))
+        >> Catch()
+               .raised<std::runtime_error>([](std::runtime_error&& e) {
+                 CHECK_STREQ("Oh no!", e.what());
+                 return Just("world");
+               });
   };
 
   CHECK_EQ("world", *e());

--- a/errors-3.cc
+++ b/errors-3.cc
@@ -1,5 +1,6 @@
 #include "eventuals/catch.h"
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/raise.h"
 
 using namespace eventuals;
@@ -7,12 +8,12 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Just("hello")
-        | Raise(std::runtime_error("Oh no!"))
-        | Catch()
-              .raised<std::exception>([](std::exception&& e) {
-                CHECK_STREQ("Oh no!", e.what());
-                return Just("world");
-              });
+        >> Raise(std::runtime_error("Oh no!"))
+        >> Catch()
+               .raised<std::exception>([](std::exception&& e) {
+                 CHECK_STREQ("Oh no!", e.what());
+                 return Just("world");
+               });
   };
 
   CHECK_EQ("world", *e());

--- a/errors-4.cc
+++ b/errors-4.cc
@@ -1,6 +1,7 @@
 #include "eventuals/expected.h"
 #include "eventuals/finally.h"
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/raise.h"
 
 using namespace eventuals;
@@ -8,8 +9,8 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Just("hello")
-        | Raise(std::runtime_error("Oh no!"))
-        | Finally([](expected<const char*, std::exception_ptr> expected) {
+        >> Raise(std::runtime_error("Oh no!"))
+        >> Finally([](expected<const char*, std::exception_ptr> expected) {
              CHECK(!expected.has_value());
              return "world";
            });

--- a/eventual-1.cc
+++ b/eventual-1.cc
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "eventuals/eventual.h"
+#include "eventuals/promisify.h"
 
 using namespace eventuals;
 

--- a/eventual-2.cc
+++ b/eventual-2.cc
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "eventuals/eventual.h"
+#include "eventuals/promisify.h"
 
 using namespace eventuals;
 

--- a/eventual-3.cc
+++ b/eventual-3.cc
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "eventuals/eventual.h"
+#include "eventuals/promisify.h"
 #include "eventuals/raise.h"
 
 using namespace eventuals;
@@ -27,7 +28,7 @@ int main(int argc, char** argv) {
         });
   };
 
-  CHECK_EQ("never slept!", *(Raise("error!") | e()));
+  CHECK_EQ("never slept!", *(Raise("error!") >> e()));
 
   return 0;
 }

--- a/eventual-4.cc
+++ b/eventual-4.cc
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "eventuals/eventual.h"
+#include "eventuals/promisify.h"
 #include "eventuals/raise.h"
 
 using namespace eventuals;
@@ -28,7 +29,7 @@ int main(int argc, char** argv) {
         });
   };
 
-  CHECK_EQ("never slept!", *(Raise("error!") | e()));
+  CHECK_EQ("never slept!", *(Raise("error!") >> e()));
 
   return 0;
 }

--- a/expected-1.cc
+++ b/expected-1.cc
@@ -1,4 +1,5 @@
 #include "eventuals/expected.h"
+#include "eventuals/promisify.h"
 #include "eventuals/then.h"
 
 using namespace eventuals;
@@ -12,7 +13,7 @@ expected<int> SomeFunction(int i) {
 }
 
 int main(int argc, char** argv) {
-  CHECK_EQ("42", *(SomeFunction(42) | Then([](int i) { return std::to_string(i); })));
+  CHECK_EQ("42", *(SomeFunction(42) >> Then([](int i) { return std::to_string(i); })));
 
   return 0;
 }

--- a/generator-1.cc
+++ b/generator-1.cc
@@ -1,6 +1,8 @@
+#include "eventuals/compose.h"
 #include "eventuals/generator.h"
 #include "eventuals/iterate.h"
 #include "eventuals/map.h"
+#include "eventuals/promisify.h"
 #include "eventuals/reduce.h"
 #include "eventuals/then.h"
 
@@ -9,7 +11,7 @@ using namespace eventuals;
 Generator::Of<std::string> SomeFunction() {
   return []() {
     return Iterate({"hello", " ", "world", "!"})
-        | Map([](std::string&& s) {
+        >> Map([](std::string&& s) {
              s[0] = std::toupper(s[0]);
              return std::move(s);
            });
@@ -19,7 +21,7 @@ Generator::Of<std::string> SomeFunction() {
 int main(int argc, char** argv) {
   auto e = []() {
     return SomeFunction()
-        | Reduce(
+        >> Reduce(
                /* result = */ std::string(),
                [](auto& result) {
                  return Then([&](auto&& value) {

--- a/interrupt-1.cc
+++ b/interrupt-1.cc
@@ -1,7 +1,9 @@
 #include <iostream>
+#include <optional>
 #include <string>
 
 #include "eventuals/eventual.h"
+#include "eventuals/promisify.h"
 
 using namespace eventuals;
 
@@ -10,15 +12,16 @@ int main(int argc, char** argv) {
     return Eventual<std::string>()
         .interruptible()
         .context("interrupted!")
-        .start([](auto& context, auto& k, Interrupt::Handler& handler) {
-          handler.Install([&]() {
+        .start([](auto& context, auto& k, std::optional<Interrupt::Handler>& handler) {
+          CHECK(handler.has_value());
+          handler->Install([&]() {
             k.Start(context);
           });
           std::cout << "nothing happening until interrupt ..." << std::endl;
         });
   };
 
-  auto [future, k]  = Promisify("[interrupt-1]", e());
+  auto [future, k] = Promisify("[interrupt-1]", e());
 
   Interrupt interrupt;
 

--- a/pipelines-1.cc
+++ b/pipelines-1.cc
@@ -1,4 +1,5 @@
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 
 // Simplifying with a using-directive; you probably will want to use
 // using-declarations, e.g., 'using eventuals::Just'.

--- a/pipelines-10.cc
+++ b/pipelines-10.cc
@@ -2,6 +2,7 @@
 
 #include "eventuals/iterate.h"
 #include "eventuals/map.h"
+#include "eventuals/promisify.h"
 #include "eventuals/reduce.h"
 #include "eventuals/then.h"
 
@@ -10,11 +11,11 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Iterate({"hello", " ", "world", "!"})
-        | Map([](std::string&& s) {
+        >> Map([](std::string&& s) {
              s[0] = std::toupper(s[0]);
              return std::move(s);
            })
-        | Reduce(
+        >> Reduce(
                /* result = */ std::string(),
                [](auto& result) {
                  return Then([&](auto&& value) {

--- a/pipelines-11.cc
+++ b/pipelines-11.cc
@@ -3,6 +3,7 @@
 #include "eventuals/iterate.h"
 #include "eventuals/loop.h"
 #include "eventuals/map.h"
+#include "eventuals/promisify.h"
 
 using namespace eventuals;
 
@@ -10,11 +11,11 @@ int main(int argc, char** argv) {
   std::string result;
   auto e = [&result]() {
     return Iterate({"hello", " ", "world", "!"})
-        | Map([&result](std::string&& s) {
+        >> Map([&result](std::string&& s) {
              s[0] = std::toupper(s[0]);
              result += std::move(s);
            })
-        | Loop();
+        >> Loop();
   };
 
   *e();

--- a/pipelines-12.cc
+++ b/pipelines-12.cc
@@ -3,17 +3,18 @@
 #include "eventuals/head.h"
 #include "eventuals/iterate.h"
 #include "eventuals/map.h"
+#include "eventuals/promisify.h"
 
 using namespace eventuals;
 
 int main(int argc, char** argv) {
   auto e = []() {
     return Iterate({"hello", " ", "world", "!"})
-        | Map([](std::string&& s) {
+        >> Map([](std::string&& s) {
              s[0] = std::toupper(s[0]);
              return std::move(s);
            })
-      | Head();
+        >> Head();
   };
 
   CHECK_EQ("Hello", *e());

--- a/pipelines-13.cc
+++ b/pipelines-13.cc
@@ -4,6 +4,7 @@
 #include "eventuals/iterate.h"
 #include "eventuals/loop.h"
 #include "eventuals/map.h"
+#include "eventuals/promisify.h"
 
 using namespace eventuals;
 
@@ -11,12 +12,12 @@ int main(int argc, char** argv) {
   auto e = []() {
     return Closure([result = std::string()]() mutable {
       return Iterate({"hello", " ", "world", "!"})
-          | Map([&result](std::string&& s) {
+          >> Map([&result](std::string&& s) {
                s[0] = std::toupper(s[0]);
                result += std::move(s);
              })
-          | Loop()
-          | Then([&result]() {
+          >> Loop()
+          >> Then([&result]() {
                return std::move(result);
              });
     });

--- a/pipelines-14.cc
+++ b/pipelines-14.cc
@@ -5,6 +5,7 @@
 #include "eventuals/let.h"
 #include "eventuals/loop.h"
 #include "eventuals/map.h"
+#include "eventuals/promisify.h"
 
 using namespace eventuals;
 
@@ -12,15 +13,15 @@ int main(int argc, char** argv) {
   auto e = []() {
     return Closure([result = std::string()]() mutable {
       return Iterate({"hello", " ", "world", "!"})
-          | Map([&result](std::string&& s) {
+          >> Map([&result](std::string&& s) {
                s[0] = std::toupper(s[0]);
                result += std::move(s);
              })
-          | Loop()
-          | Then([&result]() {
+          >> Loop()
+          >> Then([&result]() {
                return std::move(result);
              })
-          | Then(Let([](std::string& result) mutable {
+          >> Then(Let([](std::string& result) mutable {
                return Then([&result]() {
                  return std::move(result);
                });

--- a/pipelines-2.cc
+++ b/pipelines-2.cc
@@ -1,4 +1,5 @@
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/then.h"
 
 using namespace eventuals;
@@ -6,7 +7,7 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Just(42)
-        | Then([](int i) {
+        >> Then([](int i) {
              return std::to_string(i);
            });
   };

--- a/pipelines-3.cc
+++ b/pipelines-3.cc
@@ -1,4 +1,5 @@
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/then.h"
 
 using namespace eventuals;
@@ -6,7 +7,7 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Just(42)
-        | Then([](int i) {
+        >> Then([](int i) {
              return Just(std::to_string(i));
            });
   };

--- a/pipelines-4.cc
+++ b/pipelines-4.cc
@@ -1,4 +1,5 @@
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/then.h"
 
 using namespace eventuals;
@@ -6,7 +7,7 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Just(42)
-        | Then([](int i) {
+        >> Then([](int i) {
              // Returns an eventual value of type 'void'.
              return Just();
            });

--- a/pipelines-5.cc
+++ b/pipelines-5.cc
@@ -1,4 +1,5 @@
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/then.h"
 
 using namespace eventuals;
@@ -6,7 +7,7 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Just(42)
-        | Then([](int i) {
+        >> Then([](int i) {
              // Or Don't need to return anything!
              // return;
            });

--- a/pipelines-6.cc
+++ b/pipelines-6.cc
@@ -1,4 +1,5 @@
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/then.h"
 
 using namespace eventuals;
@@ -6,7 +7,7 @@ using namespace eventuals;
 int main(int argc, char** argv) {
   auto e = []() {
     return Just(42)
-        | Then([](int /* i */) {});
+        >> Then([](int /* i */) {});
   };
 
   static_assert(std::is_void_v<decltype(*e())>);

--- a/pipelines-7.cc
+++ b/pipelines-7.cc
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/then.h"
 
 using namespace eventuals;
@@ -14,9 +15,9 @@ auto SomeFunction(const std::string& s) {
 int main(int argc, char** argv) {
   auto e = []() {
     return Just("hello")
-        | Then([](std::string&& s1) {
+        >> Then([](std::string&& s1) {
              return SomeFunction(s1)
-                 | Then([s1](int length) {
+                 >> Then([s1](int length) {
                       return std::move(s1) + " has "
                           + std::to_string(length) + " characters";
                     });

--- a/pipelines-8.cc
+++ b/pipelines-8.cc
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/then.h"
 
 using namespace eventuals;

--- a/pipelines-9.cc
+++ b/pipelines-9.cc
@@ -3,18 +3,19 @@
 #include "eventuals/collect.h"
 #include "eventuals/iterate.h"
 #include "eventuals/map.h"
+#include "eventuals/promisify.h"
 
 using namespace eventuals;
 
 int main(int argc, char** argv) {
   auto e = []() {
     return Iterate({"hello", " ", "world", "!"})
-        | Map([](std::string&& s) {
+        >> Map([](std::string&& s) {
              s[0] = std::toupper(s[0]);
              return std::move(s);
            })
-        | Collect<std::vector<std::string>>()
-        | Then([](std::vector<std::string>&& v) {
+        >> Collect<std::vector<std::string>>()
+        >> Then([](std::vector<std::string>&& v) {
              std::string result;
              for (std::string& s : v) {
                result += std::move(s);

--- a/stream-1.cc
+++ b/stream-1.cc
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "eventuals/loop.h"
+#include "eventuals/promisify.h"
 #include "eventuals/stream.h"
 
 using namespace eventuals;
@@ -19,25 +20,25 @@ int main(int argc, char** argv) {
                .done([](auto& count, auto& k) {
                  k.Ended();
                })
-        | Loop<int>()
-              .context(/* sum = */ 0)
-              .body([](auto& sum, auto& stream, auto&& value) {
-                if (sum < 42) {
-                  sum += value;
-                  stream.Next();
-                } else {
-                  stream.Done();
-                }
-              })
-              .ended([](auto& sum, auto& k) {
-                k.Start(sum);
-              })
-              .fail([](auto& sum, auto& k, auto&& e) {
-                k.Fail(std::forward<decltype(e)>(e)); // Propagate error.
-              })
-              .stop([](auto& sum, auto& k) {
-                k.Stop(); // Propagate stop.
-              });
+        >> Loop<int>()
+               .context(/* sum = */ 0)
+               .body([](auto& sum, auto& stream, auto&& value) {
+                 if (sum < 42) {
+                   sum += value;
+                   stream.Next();
+                 } else {
+                   stream.Done();
+                 }
+               })
+               .ended([](auto& sum, auto& k) {
+                 k.Start(sum);
+               })
+               .fail([](auto& sum, auto& k, auto&& e) {
+                 k.Fail(std::forward<decltype(e)>(e)); // Propagate error.
+               })
+               .stop([](auto& sum, auto& k) {
+                 k.Stop(); // Propagate stop.
+               });
   };
 
   CHECK_EQ(42, *e());

--- a/task-1.cc
+++ b/task-1.cc
@@ -1,4 +1,5 @@
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/task.h"
 #include "eventuals/then.h"
 
@@ -7,7 +8,7 @@ using namespace eventuals;
 Task::Of<std::string> SomeFunction() {
   return []() {
     return Just(42)
-        | Then([](int i) {
+        >> Then([](int i) {
              return Just(std::to_string(i));
            });
   };

--- a/task-2.cc
+++ b/task-2.cc
@@ -1,4 +1,5 @@
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/task.h"
 #include "eventuals/then.h"
 
@@ -13,7 +14,7 @@ Task::From<int>::To<std::string> SomeFunction() {
 }
 
 int main(int argc, char** argv) {
-  CHECK_EQ("42", *(Just(42) | SomeFunction()));
+  CHECK_EQ("42", *(Just(42) >> SomeFunction()));
 
   return 0;
 }

--- a/task-3.cc
+++ b/task-3.cc
@@ -1,6 +1,7 @@
 #include "eventuals/if.h"
 #include "eventuals/just.h"
 #include "eventuals/let.h"
+#include "eventuals/promisify.h"
 #include "eventuals/task.h"
 #include "eventuals/then.h"
 
@@ -21,7 +22,7 @@ Task::From<int>::To<std::string>::Raises<std::overflow_error> SomeFunction() {
 }
 
 int main(int argc, char** argv) {
-  CHECK_EQ("42", *(Just(42) | SomeFunction()));
+  CHECK_EQ("42", *(Just(42) >> SomeFunction()));
 
   return 0;
 }

--- a/task-4.cc
+++ b/task-4.cc
@@ -1,4 +1,5 @@
 #include "eventuals/just.h"
+#include "eventuals/promisify.h"
 #include "eventuals/task.h"
 #include "eventuals/then.h"
 


### PR DESCRIPTION
Since 'promisify' stuff was moved from 'eventuals/scheduler.h' to
'eventuals/promisify.h' there were some build [`issues`](https://github.com/3rdparty/eventuals-tutorial/runs/7473265808?check_suite_focus=true). This PR adds
all includes needed to make all targets build successfully. Also
updates 'commit' and 'shallow_since' for eventuals.